### PR TITLE
Update PlatformIO deps

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -2,6 +2,7 @@
 platform = espressif32@6.5.0
 board = esp32dev
 framework = arduino
+platform_packages = framework-arduinoespressif32@3.20014.231204
 monitor_speed = 115200
 
 lib_deps =
@@ -9,7 +10,6 @@ lib_deps =
   adafruit/Adafruit NeoPixel @ ^1.10.6
   https://github.com/me-no-dev/ESPAsyncWebServer.git
   https://github.com/me-no-dev/AsyncTCP.git
-  https://github.com/espressif/arduino-esp32.git
 
 build_flags = 
   -DASYNC_TCP_SSL_ENABLED=0


### PR DESCRIPTION
## Summary
- remove `arduino-esp32` git reference from `lib_deps`
- pin the Arduino framework version with `platform_packages`

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687003d95c5c8332941fb80353f98897