### PR TITLE
Fix outdated esp32 package

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,8 +1,9 @@
 [env:esp32wroom]
 platform = espressif32@6.5.0
 board = esp32dev
+board_build.variant = esp32
 framework = arduino
-platform_packages = framework-arduinoespressif32@3.20014.231204
+platform_packages = framework-arduinoespressif32@^2.0.11
 monitor_speed = 115200
 
 lib_deps =


### PR DESCRIPTION
## Summary
- set `framework-arduinoespressif32` to stable version
- specify board variant for clarity

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687006972dfc8332a46bf7e434bc0f5b